### PR TITLE
Some small fixes

### DIFF
--- a/nginx-certwatch
+++ b/nginx-certwatch
@@ -99,8 +99,8 @@ if ! command -v sendmail > /dev/null 2>&1 ; then
 	echo "Binary 'sendmail' not found but required."
 	exit 1
 fi
-if ! command -v find > /dev/null 2>&1 ; then
-	echo "Binary 'find' not found but required."
+if ! command -v nginx > /dev/null 2>&1 ; then
+	echo "Binary 'nginx' not found but required."
 	exit 1
 fi
 
@@ -120,17 +120,19 @@ if ! command -v uniq > /dev/null 2>&1 ; then
 fi
 
 #
-# Paths
+# Conf file
 #
-if [ ! -d "${NGINX_CONF_PATH}" ]; then
-	echo "Nginx config path not found in: ${NGINX_CONF_PATH}"
+NGINX_CONF="${NGINX_CONF_PATH}/nginx.conf"
+if [ ! -f "${NGINX_CONF}" ]; then
+	echo "Nginx config file not found at: ${NGINX_CONF}"
 	exit 1
 fi
 
 #
-# Check if there is at least one certificate available
+# Check if there is at least one certificate available.
+# Use 'nginx -T' to only test certs loaded by nginx.
 #
-SSL_DIRECTIVES="$( $(which find) "${NGINX_CONF_PATH}" -name "*.conf" -exec grep -E '^[[:space:]]*ssl_certificate[[:space:]]+' "{}" \; )"
+SSL_DIRECTIVES="$( $(which nginx) -T -c ${NGINX_CONF} 2>/dev/null | grep -E '^[[:space:]]*ssl_certificate[[:space:]]+')"
 CERTIFICATES="$( echo "${SSL_DIRECTIVES}" | awk '{print $2}' | awk -F ';' '{print $1}' | sort | uniq )"
 
 if [ "${SSL_DIRECTIVES}" = "" ]; then

--- a/nginx-certwatch
+++ b/nginx-certwatch
@@ -130,7 +130,7 @@ fi
 #
 # Check if there is at least one certificate available
 #
-SSL_DIRECTIVES="$( $(which find) "${NGINX_CONF_PATH}" -name "*.conf" -exec grep -E '[[:space:]]*ssl_certificate[[:space:]]+' "{}" \; )"
+SSL_DIRECTIVES="$( $(which find) "${NGINX_CONF_PATH}" -name "*.conf" -exec grep -E '^[[:space:]]*ssl_certificate[[:space:]]+' "{}" \; )"
 CERTIFICATES="$( echo "${SSL_DIRECTIVES}" | awk '{print $2}' | awk -F ';' '{print $1}' | sort | uniq )"
 
 if [ "${SSL_DIRECTIVES}" = "" ]; then

--- a/nginx-certwatch
+++ b/nginx-certwatch
@@ -166,6 +166,14 @@ watch_nginx_certs()
 	sendmail_bin="$( which sendmail )"
 
 	for c in ${CERTIFICATES}; do
+		# Does the filename start with a '/'?
+		first_char=$(echo "${c}" | cut -c1)
+		# If not, prepend the nginx path
+		if [ "${first_char}" != "/" ]
+		then
+			c="${NGINX_CONF_PATH}/${c}"
+		fi
+
 		if [ -f "${c}" ]; then
 			# Check whether a warning message is needed, then issue one if so.
 			${certwatch_bin} ${opts} -q "${c}" &&

--- a/nginx-certwatch
+++ b/nginx-certwatch
@@ -133,7 +133,10 @@ fi
 # Use 'nginx -T' to only test certs loaded by nginx.
 #
 SSL_DIRECTIVES="$( $(which nginx) -T -c ${NGINX_CONF} 2>/dev/null | grep -E '^[[:space:]]*ssl_certificate[[:space:]]+')"
-CERTIFICATES="$( echo "${SSL_DIRECTIVES}" | awk '{print $2}' | awk -F ';' '{print $1}' | sort | uniq )"
+#
+# Strip any optional quotes around the filenames, and remove the trailing ';'.
+#
+CERTIFICATES="$( echo "${SSL_DIRECTIVES}" | awk '{print $2}' | tr -d \'\"\; | sort | uniq )"
 
 if [ "${SSL_DIRECTIVES}" = "" ]; then
 	echo "No SSL directives in nginx config files found"


### PR DESCRIPTION
Thanks for the useful script!

Some small changes that we needed for our site:

- exclude comment lines (old certificate files)
- use 'nginx -T' to only process active config files
- strip quotes from around filenames, if they were used in the nginx.conf
- fix non-absolute file paths